### PR TITLE
meta: add golangci-lint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,11 +20,12 @@ jobs:
       - run: npm test
   api_tests:
     docker:
-      - image: circleci/golang:1.13
+      - image: golangci/golangci-lint:v1.23.8
     working_directory: ~/repo
     steps:
       - checkout:
           path: ~/repo
+      - run: make go_lint
       - run: make go_tests
   deploy:
     docker:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,58 @@
+linters-settings:
+  govet:
+    check-shadowing: true
+  golint:
+    min-confidence: 0
+  gocyclo:
+    min-complexity: 15
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  funlen:
+    lines: 100
+    statements: 50
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - misspell
+    - scopelint
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - gocognit
+    - godox
+    - maligned
+    - prealloc
+    - gochecknoglobals
+    - nakedret
+    - gochecknoinits

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,13 @@ frontend/node_modules: frontend/package.json
 
 test: go_tests frontend_tests
 
+lint: go_lint
+
 go_tests:
 	cd api && go test ./...
+
+go_lint:
+	cd api && golangci-lint run
 
 frontend_tests: install
 	cd frontend && CI=true npm test

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,10 +14,16 @@ func TestActions(t *testing.T) {
 	defer trello.TeardownMockServer()
 
 	mockServer.AddFileResponse(trello.OwnedCardsPath(), "./trello/testdata/my_cards_response.json")
-	mockServer.AddFileResponse(trello.CardsOnListPath("nextActionsList123"), "./trello/testdata/next_actions_list_response.json")
+	mockServer.AddFileResponse(
+		trello.CardsOnListPath("nextActionsList123"),
+		"./trello/testdata/next_actions_list_response.json",
+	)
 	mockServer.AddFileResponse(trello.CardsOnListPath("projectsList456"), "./trello/testdata/projects_list_response.json")
 	mockServer.AddFileResponse(trello.ListsOnBoardPath("projectBoard789"), "./trello/testdata/board_lists_response.json")
-	mockServer.AddFileResponse(trello.CardsOnListPath("todoListId"), "./trello/testdata/project_todo_list_cards_response.json")
+	mockServer.AddFileResponse(
+		trello.CardsOnListPath("todoListId"),
+		"./trello/testdata/project_todo_list_cards_response.json",
+	)
 
 	config.SetupEnvironment("https://api.trello.com/1", "some key", "some token", "nextActionsList123", "projectsList456")
 	defer config.TeardownEnvironment()

--- a/api/config/env.go
+++ b/api/config/env.go
@@ -3,7 +3,7 @@ package config
 import "os"
 
 // SetupEnvironment sets environment variables specified in the function
-func SetupEnvironment(trelloBaseURL string, trelloKey string, trelloToken string, trelloNextActionsListID string, trelloProjectsListID string) {
+func SetupEnvironment(trelloBaseURL, trelloKey, trelloToken, trelloNextActionsListID, trelloProjectsListID string) {
 	os.Setenv("TRELLO_BASE_URL", trelloBaseURL)
 	os.Setenv("TRELLO_KEY", trelloKey)
 	os.Setenv("TRELLO_TOKEN", trelloToken)

--- a/api/trello/client.go
+++ b/api/trello/client.go
@@ -63,6 +63,7 @@ func (c *Client) getCards(relativePath string) ([]Card, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	cards := make([]Card, 0)
 	if err := json.NewDecoder(resp.Body).Decode(&cards); err != nil {
@@ -77,6 +78,7 @@ func (c *Client) getLists(relativePath string) ([]List, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	lists := make([]List, 0)
 	if err := json.NewDecoder(resp.Body).Decode(&lists); err != nil {

--- a/api/trello/mockserver.go
+++ b/api/trello/mockserver.go
@@ -16,7 +16,7 @@ type MockServer struct {
 }
 
 // CreateMockServer will create and activate a mock server
-func CreateMockServer(baseURL string, key string, token string) *MockServer {
+func CreateMockServer(baseURL, key, token string) *MockServer {
 	httpmock.Activate()
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -32,7 +32,7 @@ func TeardownMockServer() {
 
 // AddFileResponse will return the contents of the specified file when the specified path on the mock server is
 // requested
-func (m *MockServer) AddFileResponse(urlPath string, filePath string) {
+func (m *MockServer) AddFileResponse(urlPath, filePath string) {
 	bytes, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Added the new version of gometalint, which can be found at: https://github.com/golangci/golangci-lint.

The config is in `.golangci.yml` - feel free to change anything you don't
want/like. All the options are listed here: https://github.com/golangci/golangci-lint/blob/master/.golangci.example.yml

I fixed a few of the issues that it complained about, the tests pass but
I haven't run the service at all so it might break something.

Edit: Btw you can enable this to run and report issues on pull requests via https://golangci.com - rather than having it run in CI manually