### PR TITLE
Simplify continuous deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,10 +19,8 @@ push:
 
 .PHONY: deploy
 deploy:
-	echo ${DOCKER_HUB_TOKEN} | ssh docker-deploy@${DOCKER_SERVER} "docker login -u stevecshanks --password-stdin"
-	ssh docker-deploy@${DOCKER_SERVER} "docker-compose -f docker-compose-production.yml down --rmi all --remove-orphans || true"
-	scp docker-compose-production.yml docker-deploy@${DOCKER_SERVER}:~/docker-compose-production.yml
-	ssh docker-deploy@${DOCKER_SERVER} "source .env && docker-compose -f docker-compose-production.yml pull && docker-compose -f docker-compose-production.yml up --no-build -d"
+	scp docker-compose-production.yml docker-deploy.sh docker-deploy@${DOCKER_SERVER}:~/
+	echo ${DOCKER_HUB_TOKEN} | ssh docker-deploy@${DOCKER_SERVER} "/bin/bash docker-deploy.sh"
 
 .PHONY: test
 test: $(SUBDIRS)

--- a/docker-deploy.sh
+++ b/docker-deploy.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+source .env
+
+docker login -u stevecshanks --password-stdin
+docker-compose -f docker-compose-production.yml pull
+docker-compose -f docker-compose-production.yml down --remove-orphans
+docker-compose -f docker-compose-production.yml up --no-build -d


### PR DESCRIPTION
* Moved docker commands to script, so not connecting with SSH for each one
* Removed the --rmi flag from the docker-compose down command, as we're
  updating the images in the docker-compose pull anyway
* Moved the pull before the down to minimise downtime