### PR TITLE
Use board cards instead of parsing link in description

### DIFF
--- a/api/internal/nextactions/nextactions.go
+++ b/api/internal/nextactions/nextactions.go
@@ -164,9 +164,9 @@ func getProjectBoardID(projectCard *trello.Card) (string, error) {
 		return "", err
 	}
 
-	matches := boardIDRegex.FindStringSubmatch(projectCard.Description)
+	matches := boardIDRegex.FindStringSubmatch(projectCard.Name)
 	if len(matches) != 2 {
-		return "", fmt.Errorf("could not parse board ID from description on card %s", projectCard.Name)
+		return "", fmt.Errorf("could not parse board ID from card name %s", projectCard.Name)
 	}
 	return matches[1], nil
 }

--- a/api/internal/nextactions/nextactions_test.go
+++ b/api/internal/nextactions/nextactions_test.go
@@ -210,8 +210,8 @@ func TestErrorWithCardsOnProjectsListReturnsError(t *testing.T) {
 	}
 }
 
-func TestMissingDescriptionOnProjectCardReturnsError(t *testing.T) {
-	brokenProjectCard := trello.Card{ID: "an id", Name: "a name", Description: "invalid"}
+func TestInvalidNameOnProjectCardReturnsError(t *testing.T) {
+	brokenProjectCard := trello.Card{ID: "an id", Name: "invalid"}
 
 	fakeClient := newFakeTrelloClient()
 	fakeClient.AddCardOnList("projectsListId", &brokenProjectCard)
@@ -228,7 +228,7 @@ func TestMissingDescriptionOnProjectCardReturnsError(t *testing.T) {
 }
 
 func TestErrorWithListsOnBoardReturnsError(t *testing.T) {
-	projectCard := trello.Card{ID: "an id", Name: "a name", Description: "https://trello.com/b/broken/a-broken-card"}
+	projectCard := trello.Card{ID: "an id", Name: "https://trello.com/b/broken/a-broken-card"}
 	expectedError := fmt.Errorf("an error")
 
 	fakeClient := newFakeTrelloClient()
@@ -247,7 +247,7 @@ func TestErrorWithListsOnBoardReturnsError(t *testing.T) {
 }
 
 func TestMissingTodoListOnProjectBoardReturnsError(t *testing.T) {
-	projectCard := trello.Card{ID: "an id", Name: "a name", Description: "https://trello.com/b/empty"}
+	projectCard := trello.Card{ID: "an id", Name: "https://trello.com/b/empty"}
 
 	fakeClient := newFakeTrelloClient()
 	fakeClient.AddCardOnList("projectsListId", &projectCard)
@@ -264,7 +264,7 @@ func TestMissingTodoListOnProjectBoardReturnsError(t *testing.T) {
 }
 
 func TestErrorWithTodoListReturnsError(t *testing.T) {
-	projectCard := trello.Card{ID: "an id", Name: "a name", Description: "https://trello.com/b/aBoardId"}
+	projectCard := trello.Card{ID: "an id", Name: "https://trello.com/b/aBoardId"}
 	todoList := trello.List{ID: "todoListId", Name: "Todo"}
 	expectedError := fmt.Errorf("an error")
 
@@ -285,7 +285,7 @@ func TestErrorWithTodoListReturnsError(t *testing.T) {
 }
 
 func TestEmptyTodoListDoesNotReturnAnAction(t *testing.T) {
-	projectCard := trello.Card{ID: "an id", Name: "a name", Description: "https://trello.com/b/aBoardId"}
+	projectCard := trello.Card{ID: "an id", Name: "https://trello.com/b/aBoardId"}
 	todoList := trello.List{ID: "todoListId", Name: "Todo"}
 
 	fakeClient := newFakeTrelloClient()
@@ -304,7 +304,7 @@ func TestEmptyTodoListDoesNotReturnAnAction(t *testing.T) {
 }
 
 func TestFirstTodoListItemsAreReturnedAsActions(t *testing.T) {
-	projectCard := trello.Card{ID: "an id", Name: "a name", Description: "https://trello.com/b/aBoardId"}
+	projectCard := trello.Card{ID: "an id", Name: "https://trello.com/b/aBoardId"}
 	todoList := trello.List{ID: "todoListId", Name: "Todo"}
 
 	fakeClient := newFakeTrelloClient()

--- a/api/internal/trello/card.go
+++ b/api/internal/trello/card.go
@@ -28,12 +28,11 @@ func (u *urlWrapper) UnmarshalJSON(data []byte) error {
 
 // Card represents a Trello card returned via the API
 type Card struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Description string     `json:"desc"`
-	DueBy       *time.Time `json:"due"`
-	URL         url.URL    `json:"-"`
-	BoardID     string     `json:"idBoard"`
+	ID      string     `json:"id"`
+	Name    string     `json:"name"`
+	DueBy   *time.Time `json:"due"`
+	URL     url.URL    `json:"-"`
+	BoardID string     `json:"idBoard"`
 }
 
 type cardAlias Card

--- a/api/internal/trello/testdata/projects_list_response.json
+++ b/api/internal/trello/testdata/projects_list_response.json
@@ -4,10 +4,8 @@
     "checkItemStates": null,
     "closed": false,
     "dateLastActivity": "2020-03-06T11:09:40.297Z",
-    "desc": "https://trello.com/b/projectBoard789/my-project",
-    "descData": {
-      "emoji": {}
-    },
+    "desc": "",
+    "descData": null,
     "dueReminder": null,
     "idBoard": "123456789012345678901234",
     "idList": "123456789012345678901234",
@@ -16,10 +14,11 @@
     "idAttachmentCover": null,
     "idLabels": [],
     "manualCoverAttachment": false,
-    "name": "My Project",
+    "name": "https://trello.com/b/projectBoard789/my-project",
     "pos": 5521664,
     "shortLink": "defg4567",
     "isTemplate": false,
+    "cardRole": "board",
     "badges": {
       "attachmentsByType": {
         "trello": {
@@ -48,7 +47,7 @@
     "labels": [],
     "shortUrl": "https://trello.com/c/defg4567",
     "subscribed": false,
-    "url": "https://trello.com/c/defg4567/1-my-project",
+    "url": "https://trello.com/c/defg4567/1-https-trellocom-b-projectBoard789-my-project",
     "cover": {
       "idAttachment": null,
       "color": null,

--- a/api/internal/trello/trello_test.go
+++ b/api/internal/trello/trello_test.go
@@ -23,20 +23,18 @@ func TestClientOwnedCardsReturnsExpectedResponse(t *testing.T) {
 	expectedDueBy, _ := time.Parse(time.RFC3339, "2020-01-01T10:30:00.000Z")
 	expectedURL1, _ := url.Parse("https://trello.com/c/abcd1234/10-my-first-card")
 	expectedCard1 := Card{
-		ID:          "myFirstCardId",
-		Name:        "My First Action",
-		Description: "",
-		DueBy:       &expectedDueBy,
-		URL:         *expectedURL1,
-		BoardID:     "myBoardId",
+		ID:      "myFirstCardId",
+		Name:    "My First Action",
+		DueBy:   &expectedDueBy,
+		URL:     *expectedURL1,
+		BoardID: "myBoardId",
 	}
 	expectedURL2, _ := url.Parse("https://trello.com/c/bcde2345/11-my-second-card")
 	expectedCard2 := Card{
-		ID:          "mySecondCardId",
-		Name:        "My Second Action",
-		Description: "",
-		URL:         *expectedURL2,
-		BoardID:     "myBoardId",
+		ID:      "mySecondCardId",
+		Name:    "My Second Action",
+		URL:     *expectedURL2,
+		BoardID: "myBoardId",
 	}
 
 	assertCardsMatchExpected(t, cards, []Card{expectedCard1, expectedCard2})
@@ -58,12 +56,11 @@ func TestClientCardsOnList(t *testing.T) {
 	expectedDueBy, _ := time.Parse(time.RFC3339, "2020-01-15T10:29:59.000Z")
 	expectedURL, _ := url.Parse("https://trello.com/c/cdef3456/33-my-third-card")
 	expectedCard1 := Card{
-		ID:          "todoCardId",
-		Name:        "Todo Action",
-		Description: "a description",
-		DueBy:       &expectedDueBy,
-		URL:         *expectedURL,
-		BoardID:     "myBoardId",
+		ID:      "todoCardId",
+		Name:    "Todo Action",
+		DueBy:   &expectedDueBy,
+		URL:     *expectedURL,
+		BoardID: "myBoardId",
 	}
 
 	assertCardsMatchExpected(t, cards, []Card{expectedCard1})
@@ -158,7 +155,6 @@ func assertCardsMatchExpected(t *testing.T, cards, expectedCards []Card) {
 func cardsAreEqual(card, other *Card) bool {
 	return (card.ID == other.ID &&
 		card.Name == other.Name &&
-		card.Description == other.Description &&
 		((card.DueBy == nil && other.DueBy == nil) || card.DueBy.Equal(*other.DueBy)) &&
 		card.URL.String() == other.URL.String() &&
 		card.BoardID == other.BoardID)


### PR DESCRIPTION
Trello now supports board cards which link directly to a board, so we no
longer need to parse the board URL from the description.